### PR TITLE
Fix step count support

### DIFF
--- a/BMI160_i2c/__init__.py
+++ b/BMI160_i2c/__init__.py
@@ -732,8 +732,8 @@ class Driver:
   # @see registers.STEP_CNT_L
   def getStepCount(self):
     buffer = [0]*2
-    buffer[0] = registers.STEP_CNT_L
-    serial_buffer_transfer(buffer, 1, 2)
+    buffer[0] = self._reg_read(registers.STEP_CNT_L)
+    buffer[1] = self._reg_read(registers.STEP_CNT_H)
     return ((buffer[1]) << 8) | buffer[0]
 
   # Resets the current number of detected step movements (Step Count) to 0.
@@ -1246,7 +1246,6 @@ class Driver:
   def getFIFOCount(self):
     buffer = [0]*2
     buffer[0] = registers.FIFO_LENGTH_0
-    serial_buffer_transfer(buffer, 1, 2)
     return ((buffer[1]) << 8) | buffer[0]
 
   # Reset the FIFO.
@@ -1317,7 +1316,6 @@ class Driver:
     # TODO fix here
     if (length):
       data[0] = registers.FIFO_DATA
-      serial_buffer_transfer(data, 1, length)
 
   # Get full set of interrupt status bits from INT_STATUS[0] register.
   # Interrupts are typically cleared automatically.

--- a/BMI160_i2c/definitions.py
+++ b/BMI160_i2c/definitions.py
@@ -43,3 +43,20 @@ FIFO_TIME_EN_BIT    = (1)
 FIFO_MAG_EN_BIT     = (5)
 FIFO_ACC_EN_BIT     = (6)
 FIFO_GYR_EN_BIT     = (7)
+
+## Step counter definitions
+STEP_MODE_NORMAL    = (0)
+STEP_MODE_SENSITIVE = (1)
+STEP_MODE_ROBUST    = (2)
+STEP_MODE_UNKNOWN   = (0)
+STEP_BUF_MIN_BIT    = (0)
+STEP_CNT_EN_BIT     = (3)
+STEP_EN_BIT         = (3)
+STEP_BUF_MIN_LEN    = (4)
+
+## Interrupt definitions
+INT1_OUTPUT_EN      = (3)
+INT1_OD             = (2)
+INT1_LVL            = (1)
+LATCH_MODE_BIT      = (0)
+LATCH_MODE_LEN      = (4)

--- a/examples/all.py
+++ b/examples/all.py
@@ -5,6 +5,21 @@ print('Trying to initialize the sensor...')
 sensor = Driver()
 print('Initialization done')
 
+# Step detection requires interrupt config
+# See https://github.com/BoschSensortec/BMI160_driver#configuring-step-detector-interrupt
+sensor.setIntStepEnabled(True)
+# push-pull mode interrupt
+sensor.setInterruptDrive(0)
+# 0 = non-latched
+sensor.setInterruptLatch(0)
+# 0 = active-high
+sensor.setInterruptMode(0)
+sensor.setIntEnabled(True)
+# Normal step detection mode
+sensor.setStepDetectionMode(definitions.STEP_MODE_NORMAL)
+sensor.resetStepCount()
+sensor.setStepCountEnabled(True)
+    
 while True:
   data = sensor.getMotion6()
   # fetch all gyro and acclerometer values
@@ -16,5 +31,6 @@ while True:
     'ay': data[4],
     'az': data[5]
   })
+  print("Step count: ", sensor.getStepCount())
   sleep(0.1)
 


### PR DESCRIPTION
By adding missing definitions for the step counter and interrupts.

Remove serial_buffer_transfer() calls, as they don't exist on the Pi.
Add the step counter initialisation and use to the example.